### PR TITLE
Specify the redis database to use depending on the environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,4 +64,6 @@ Rails.application.configure do
   end
 
   Sidekiq.logger.level = Logger::WARN
+
+  config.redis_database = 'redis://localhost:6379/0'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,4 +81,6 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   Sidekiq.logger.level = Logger::WARN
+
+  config.redis_database = 'redis://localhost:6379/0'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,6 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   Sidekiq.logger.level = Logger::WARN
+
+  config.redis_database = 'redis://localhost:6379/0'
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: Rails.configuration.redis_database }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: Rails.configuration.redis_database }
+end


### PR DESCRIPTION
### Contenu de la PR
Le but de la PR est de configurer watchdoge pour utiliser différentes base de données Redis en fonction de l'environnement ; les fichiers de configuration par environnement sont déployés par le Ansible.