### PR TITLE
Mise à jour des requêtes ElasticSearch pour le nouveau mapping

### DIFF
--- a/app/data/queries/apis_usage.json.erb
+++ b/app/data/queries/apis_usage.json.erb
@@ -13,7 +13,7 @@
         },
         {
           "term": {
-            "user_access.jti.keyword": {
+            "user_access.jti": {
               "value": "<%= jti %>"
             }
           }

--- a/app/data/queries/availability_history.json
+++ b/app/data/queries/availability_history.json
@@ -12,9 +12,9 @@
           }
         },
         {
-          "term": {
-            "parameters.context.keyword": {
-              "value": "Ping"
+          "match": {
+            "parameters.context": {
+              "query": "Ping"
             }
           }
         }

--- a/app/data/queries/availability_history_shortened.json
+++ b/app/data/queries/availability_history_shortened.json
@@ -12,9 +12,9 @@
           }
         },
         {
-          "term": {
-            "parameters.context.keyword": {
-              "value": "Ping"
+          "match": {
+            "parameters.context": {
+              "query": "Ping"
             }
           }
         }

--- a/app/data/queries/current_status.json
+++ b/app/data/queries/current_status.json
@@ -17,9 +17,9 @@
           }
         },
         {
-          "term": {
-            "parameters.context.keyword": {
-              "value": "Ping"
+          "match": {
+            "parameters.context": {
+              "query": "Ping"
             }
           }
         }

--- a/app/data/queries/homepage_status.json
+++ b/app/data/queries/homepage_status.json
@@ -9,9 +9,9 @@
           }
         },
         {
-          "term": {
-            "parameters.context.keyword": {
-              "value": "Ping"
+          "match": {
+            "parameters.context": {
+              "query": "Ping"
             }
           }
         }

--- a/app/data/queries/last_api_usage.json.erb
+++ b/app/data/queries/last_api_usage.json.erb
@@ -26,9 +26,9 @@
           }
         },
         {
-          "term": {
-            "parameters.context.keyword": {
-              "value": "Ping"
+          "match": {
+            "parameters.context": {
+              "query": "Ping"
             }
           }
         },

--- a/app/data/queries/last_calls.json.erb
+++ b/app/data/queries/last_calls.json.erb
@@ -13,7 +13,7 @@
         },
         {
           "term": {
-            "user_access.jti.keyword": {
+            "user_access.jti": {
               "value": "<%= jti %>"
             }
           }


### PR DESCRIPTION
Le [mapping](https://gitlab.com/etalab/api-entreprise/very_ansible/-/merge_requests/145) ElasticSearch implique des ajustements mineurs pour que les requêtes du dashboard continuent à fonctionner :

- `parameters.context` n'a plus de sous-champ `keyword` donc on fait une recherche textuelle sur le champ lui-même avec `match` (plutôt que `term`) ;
- similairement pour `user_access.jti` mais on garde une recherche `term` qui convient aux champs de type `keyword`.

J'ai testé les changements en faisant des requêtes après modification et les résultat sont bien retournés par ES.